### PR TITLE
Development environment setup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,11 @@ module.exports = {
 		es2017: true,
 		node: true
 	},
+	ignorePatterns: [
+		'src/lib/luxmty-skin/',
+		'src/routes/sending/*/partur/*/quality-selector.js',
+		'src/routes/sending/*/partur/*/quality-selector/',
+	],
 	overrides: [
 		{
 			files: ['*.svelte'],

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,8 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+# Vendored code
+src/lib/luxmty-skin/
+src/routes/sending/*/partur/*/quality-selector.js
+src/routes/sending/*/partur/*/quality-selector/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **SvelteKit 2 / Svelte 5** static SPA for streaming Faroese children's TV shows (KVF Barnasendingar). No backend, no database, no Docker.
+
+### Running the app
+
+- `npm run dev` starts the Vite dev server on port 5173.
+- Show/episode data is pre-bundled in `src/lib/assets/shows.json`; no scraping needed to run locally.
+- Video playback streams from `vod.kringvarp.fo` (external); requires network access.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Dev server | `npm run dev` |
+| Build | `npm run build` |
+| Lint | `npm run lint` |
+| Type check | `npm run check` |
+| Format | `npm run format` |
+
+### Known pre-existing issues
+
+- `npm run lint` exits non-zero due to pre-existing Prettier formatting issues in vendored files and config.
+- `npm run check` reports ~128 TS errors, almost all from vendored JS files (`quality-selector.js`, `plugin.js`) and a few in Svelte components. These are pre-existing and do not affect the build or runtime.
+- The build produces chunk-size warnings for `shows.json` and the video player node; these are informational only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,16 @@ This is a **SvelteKit 2 / Svelte 5** static SPA for streaming Faroese children's
 | Type check | `npm run check` |
 | Format | `npm run format` |
 
+### Vendored code
+
+Vendored third-party JS lives in two locations and is excluded from lint/type checks:
+- `src/lib/luxmty-skin/` — video player skin (CSS/JS/HTML)
+- `src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector.js` and `quality-selector/` — HLS quality selector plugin
+
+These are ignored via `.prettierignore`, `.eslintrc.cjs` `ignorePatterns`, `tsconfig.json` `exclude`, and `// @ts-nocheck` directives.
+
 ### Known pre-existing issues
 
-- `npm run lint` exits non-zero due to pre-existing Prettier formatting issues in vendored files and config.
-- `npm run check` reports ~128 TS errors, almost all from vendored JS files (`quality-selector.js`, `plugin.js`) and a few in Svelte components. These are pre-existing and do not affect the build or runtime.
+- `npm run lint` exits non-zero due to pre-existing Prettier formatting issues in non-vendored files (e.g. `.eslintrc.cjs`, `src/app.html`, `vercel.json`).
+- `npm run check` reports 3 TS errors in `+page.svelte` (video player page) for missing type definitions on the Video.js `Player` type. These are pre-existing and do not affect the build or runtime.
 - The build produces chunk-size warnings for `shows.json` and the video player node; these are informational only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,34 +2,50 @@
 
 ## Cursor Cloud specific instructions
 
-This is a **SvelteKit 2 / Svelte 5** static SPA for streaming Faroese children's TV shows (KVF Barnasendingar). No backend, no database, no Docker.
+**SvelteKit 2 / Svelte 5** static SPA for streaming Faroese children's TV shows from KVF (Kringvarp Føroya). No backend, no database, no Docker. Uses `npm` as the package manager (see `package-lock.json`).
 
-### Running the app
+### Architecture
 
-- `npm run dev` starts the Vite dev server on port 5173.
-- Show/episode data is pre-bundled in `src/lib/assets/shows.json`; no scraping needed to run locally.
-- Video playback streams from `vod.kringvarp.fo` (external); requires network access.
+- Static SPA built with `@sveltejs/adapter-static`; output goes to `dist/`. SSR is disabled.
+- Show/episode metadata is pre-bundled in `src/lib/assets/shows.json` (scraped from `kvf.fo` via `npm run scrape`, but scraping is not needed to develop or run the app).
+- Video playback streams HLS from `vod.kringvarp.fo` (external server); requires network access.
+- Watch history is tracked in browser `localStorage` (see `src/lib/watched.ts`).
 
-### Key commands
+### Routes
+
+| Route | File | Description |
+|-------|------|-------------|
+| `/` | `src/routes/+page.svelte` | Show grid (homepage) |
+| `/sending/[showTitle]` | `src/routes/sending/[showTitle]/+page.svelte` | Episode list for a show |
+| `/sending/[showTitle]/partur/[episodeTitle]` | `src/routes/sending/[showTitle]/partur/[episodeTitle]/+page.svelte` | Video player |
+
+### Commands
+
+See `package.json` `scripts`. Key ones:
 
 | Task | Command |
 |------|---------|
-| Dev server | `npm run dev` |
+| Dev server | `npm run dev` (port 5173) |
 | Build | `npm run build` |
-| Lint | `npm run lint` |
+| Lint (Prettier + ESLint) | `npm run lint` |
 | Type check | `npm run check` |
 | Format | `npm run format` |
 
+### ESLint caveat
+
+ESLint 9 is installed but the project uses the legacy `.eslintrc.cjs` config format. Running `npx eslint .` directly fails; the `npm run lint` script works because Prettier runs first (and currently exits non-zero before ESLint executes). To run ESLint standalone: `ESLINT_USE_FLAT_CONFIG=false npx eslint .`
+
 ### Vendored code
 
-Vendored third-party JS lives in two locations and is excluded from lint/type checks:
-- `src/lib/luxmty-skin/` — video player skin (CSS/JS/HTML)
+Vendored third-party JS in two locations, excluded from all lint/type checks:
+
+- `src/lib/luxmty-skin/` — Luxmty video player skin (CSS/JS/HTML)
 - `src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector.js` and `quality-selector/` — HLS quality selector plugin
 
-These are ignored via `.prettierignore`, `.eslintrc.cjs` `ignorePatterns`, `tsconfig.json` `exclude`, and `// @ts-nocheck` directives.
+Exclusions configured in `.prettierignore`, `.eslintrc.cjs` `ignorePatterns`, `tsconfig.json` `exclude`, and `// @ts-nocheck` directives in the vendored JS files. The `// @ts-nocheck` directives are necessary because `tsconfig.json` `exclude` does not apply to files resolved through imports.
 
 ### Known pre-existing issues
 
-- `npm run lint` exits non-zero due to pre-existing Prettier formatting issues in non-vendored files (e.g. `.eslintrc.cjs`, `src/app.html`, `vercel.json`).
-- `npm run check` reports 3 TS errors in `+page.svelte` (video player page) for missing type definitions on the Video.js `Player` type. These are pre-existing and do not affect the build or runtime.
-- The build produces chunk-size warnings for `shows.json` and the video player node; these are informational only.
+- `npm run lint` exits non-zero due to Prettier formatting issues in non-vendored files (`.eslintrc.cjs`, `src/app.html`, `vercel.json`, `src/lib/assets/shows.json`).
+- `npm run check` reports 3 TS errors in the video player page (`+page.svelte`) for missing type definitions on the Video.js `Player` type (`titleBar`, `hlsQualitySelector`). These do not affect the build or runtime.
+- Build produces chunk-size warnings for the bundled `shows.json` data and video player dependencies; informational only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1016,7 +1016,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/cookie": "^0.6.0",
 				"cookie": "^0.6.0",
@@ -1072,6 +1071,7 @@
 			"integrity": "sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"debug": "^4.3.7"
 			},
@@ -1165,7 +1165,6 @@
 			"integrity": "sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.11.0",
 				"@typescript-eslint/types": "8.11.0",
@@ -1396,7 +1395,6 @@
 			"integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1755,6 +1753,7 @@
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1860,7 +1859,6 @@
 			"integrity": "sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.11.0",
@@ -3077,7 +3075,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.1.0",
@@ -3191,7 +3188,6 @@
 			"integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -3532,7 +3528,6 @@
 			"integrity": "sha512-Sl8UFHlBvF54aK8MElFvyvaUfPE2REOz6LnhR2pBClCL11MU4qpn4V+KgAggaXxDyrP2iQixvHbtpHqL/zXlSQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.3.0",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3589,6 +3584,21 @@
 				"picomatch": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/svelte-check/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
@@ -3807,7 +3817,6 @@
 			"integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3845,7 +3854,6 @@
 			"resolved": "https://registry.npmjs.org/video.js/-/video.js-8.19.1.tgz",
 			"integrity": "sha512-MVuayhXpzTBv5Jk3nYEU2akawPhuBBlizEbpQGx2i+6FiBmqxGjkrkLdDLOzG54ut7xapjp26IfWQLGSpeLmcQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.5",
 				"@videojs/http-streaming": "^3.15.0",
@@ -3914,7 +3922,6 @@
 			"integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -4405,6 +4412,7 @@
 			"integrity": "sha512-iKKfOMBHob2WxEJbqbJjHAkmYgvFDPhuqrO82om83S8RLk+17FtyMBfcyeH8GqD0ihShtkMW/zzJgiA51hCNCQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"workspaces": [
 				"tests/deps/*",
 				"tests/projects/*"

--- a/src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector.js
+++ b/src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import videojs from 'video.js';
 
 var version = '1.1.5';

--- a/src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector/concrete-button.js
+++ b/src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector/concrete-button.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import videojs from 'video.js';
 
 const VideoJsButtonClass = videojs.getComponent('MenuButton');

--- a/src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector/concrete-menu-item.js
+++ b/src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector/concrete-menu-item.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import videojs from 'video.js';
 
 // Concrete classes

--- a/src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector/plugin.js
+++ b/src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector/plugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* 
     Source:
     https://github.com/eban5/videojs-hls-quality-selector/blob/2b9d89799331445e9b15e8d6da0da5609b49ba35/src/plugin.js

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,11 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	},
-	"exclude": ["./src/lib/luxmty-skin/**/*"]
+	"exclude": [
+		"./src/lib/luxmty-skin/**/*",
+		"./src/routes/sending/*/partur/*/quality-selector.js",
+		"./src/routes/sending/*/partur/*/quality-selector/**/*"
+	]
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//


### PR DESCRIPTION
Set up the development environment and configure lint and type checking to ignore vendored code.

The codebase contains vendored JavaScript files that produce numerous linting and type checking errors. This PR configures Prettier, ESLint, and TypeScript to exclude these files, allowing developers to focus on issues within the primary codebase. It also includes the initial setup of the development environment and `AGENTS.md` documentation.

---
<p><a href="https://cursor.com/agents/bc-edfa95f0-97f3-4cf5-972c-a762cba1e265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edfa95f0-97f3-4cf5-972c-a762cba1e265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only changes that adjust ESLint/Prettier/TypeScript scopes and add documentation; runtime behavior should be unaffected aside from vendored files no longer being linted/type-checked.
> 
> **Overview**
> Improves local developer ergonomics by excluding vendored third‑party player code from ESLint, Prettier, and TypeScript checking (via `.eslintrc.cjs` `ignorePatterns`, `.prettierignore`, and `tsconfig.json` `exclude`).
> 
> Adds `// @ts-nocheck` headers to the vendored HLS quality-selector plugin files to suppress TS errors, and introduces `AGENTS.md` documenting project setup, vendored-code locations, and known pre-existing lint/typecheck issues.
> 
> Lockfile updates reflect dependency metadata/structure changes only (no intentional runtime dependency changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b62e2c58e3ef54a9bed88c6c8c3c16ac767d2f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->