### PR TITLE
Update AGENTS.md to match current project state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,22 +30,30 @@ See `package.json` `scripts`. Key ones:
 | Lint (Prettier + ESLint) | `npm run lint`            |
 | Type check               | `npm run check`           |
 | Format                   | `npm run format`          |
+| Re-scrape KVF metadata   | `npm run scrape`          |
+| Download a show locally  | `npm run download-show`   |
 
-### ESLint caveat
+`scripts/` also contains `keepawake.ts` (a cross-platform wake-lock helper imported by `download-show.ts`) and `delete_duplicates.ts` (run automatically at the end of `npm run scrape`).
 
-ESLint 9 is installed but the project uses the legacy `.eslintrc.cjs` config format. Running `npx eslint .` directly fails; the `npm run lint` script works because Prettier runs first (and currently exits non-zero before ESLint executes). To run ESLint standalone: `ESLINT_USE_FLAT_CONFIG=false npx eslint .`
+### Deployment
+
+`vercel.json` configures Vercel to rewrite all paths to `/` so the static SPA's client-side router handles deep links (`adapter-static` is configured with `fallback: 'index.html'` in `svelte.config.js`).
+
+### ESLint config
+
+ESLint 9 flat config in `eslint.config.js`. `npx eslint .` works directly; no legacy `.eslintrc` file is used.
 
 ### Vendored code
 
 Vendored third-party JS in two locations, excluded from all lint/type checks:
 
-- `src/lib/luxmty-skin/` — Luxmty video player skin (CSS/JS/HTML)
+- `src/lib/luxmty-skin/` — Luxmty video player skin (CSS/JS/HTML), plus the original `videojsluxmtyplayerskin.zip`
 - `src/routes/sending/[showTitle]/partur/[episodeTitle]/quality-selector.js` and `quality-selector/` — HLS quality selector plugin
 
-Exclusions configured in `.prettierignore`, `.eslintrc.cjs` `ignorePatterns`, `tsconfig.json` `exclude`, and `// @ts-nocheck` directives in the vendored JS files. The `// @ts-nocheck` directives are necessary because `tsconfig.json` `exclude` does not apply to files resolved through imports.
+Exclusions configured in `.prettierignore`, `eslint.config.js` (`ignores`), `tsconfig.json` `exclude`, and `// @ts-nocheck` directives in the vendored JS files. The `// @ts-nocheck` directives are necessary because `tsconfig.json` `exclude` does not apply to files resolved through imports.
 
 ### Known pre-existing issues
 
-- `npm run lint` exits non-zero due to Prettier formatting issues in non-vendored files (`.eslintrc.cjs`, `src/app.html`, `vercel.json`, `src/lib/assets/shows.json`).
-- `npm run check` reports 3 TS errors in the video player page (`+page.svelte`) for missing type definitions on the Video.js `Player` type (`titleBar`, `hlsQualitySelector`). These do not affect the build or runtime.
+- `npm run lint` exits non-zero because Prettier flags `src/lib/assets/shows.json` as not formatted. ESLint itself passes.
+- `npm run check` reports 7 TS errors: 2 in the video player page for missing Video.js `Player` type members (`titleBar`, `hlsQualitySelector`), plus 5 in the route pages for `undefined` index/parameter types. None affect the build or runtime.
 - Build produces chunk-size warnings for the bundled `shows.json` data and video player dependencies; informational only.


### PR DESCRIPTION
- ESLint already migrated to flat config (`eslint.config.js`); drop the
  legacy `.eslintrc.cjs` workaround and update vendored-exclusion path.
- Add `npm run scrape` and `npm run download-show` to the commands table
  and note the `keepawake.ts` / `delete_duplicates.ts` helpers in `scripts/`.
- Document the Vercel SPA rewrite in `vercel.json`.
- Correct the known-issues section: `npm run lint` only fails on
  `shows.json` now, and `npm run check` reports 7 TS errors (not 3).