### PR TITLE
Describe project purpose and user flow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,35 @@
 # AGENTS.md
 
+## Purpose
+
+An alternative frontend for the children's TV catalogue on **kvf.fo** (Kringvarp Føroya, the Faroese public broadcaster). The official site lists every children's show under https://kvf.fo/vit/sjonvarp/sendingar; this project re-presents that catalogue as a kid-friendly grid UI with autoplay and a "watched" indicator, so a child can browse and watch unattended.
+
+The app has three pages, in this user flow:
+
+1. **Front page (`/`)** — grid of every show from the pre-scraped `src/lib/assets/shows.json` (~55 shows). Each tile shows the show's poster and title; clicking a tile opens that show's page. See `src/routes/+page.svelte`.
+2. **Show page (`/sending/[showTitle]`)** — grid of every episode for the chosen show, sorted by date. Episodes the user has already finished are marked with a "Sæð" ("watched") overlay; a "Nulstilla 'Sæð'" button clears the show's watch history. Clicking an episode opens the player. See `src/routes/sending/[showTitle]/+page.svelte`.
+3. **Episode page (`/sending/[showTitle]/partur/[episodeTitle]`)** — a Video.js player that streams HLS from `vod.kringvarp.fo` for the episode's `mediaId`. It requests fullscreen on mount, marks the episode watched in `localStorage` when it ends, and auto-advances to the next episode in the show's list. See `src/routes/sending/[showTitle]/partur/[episodeTitle]/+page.svelte`.
+
+Watched state lives in `localStorage` only (see `src/lib/watched.ts`); there is no account system or server-side state.
+
 ## Cursor Cloud specific instructions
 
-**SvelteKit 2 / Svelte 5** static SPA for streaming Faroese children's TV shows from KVF (Kringvarp Føroya). No backend, no database, no Docker. Uses `npm` as the package manager (see `package-lock.json`).
+**SvelteKit 2 / Svelte 5** static SPA. No backend, no database, no Docker. Uses `npm` as the package manager (see `package-lock.json`).
 
 ### Architecture
 
 - Static SPA built with `@sveltejs/adapter-static`; output goes to `dist/`. SSR is disabled.
 - Show/episode metadata is pre-bundled in `src/lib/assets/shows.json` (scraped from `kvf.fo` via `npm run scrape`, but scraping is not needed to develop or run the app).
-- Video playback streams HLS from `vod.kringvarp.fo` (external server); requires network access.
-- Watch history is tracked in browser `localStorage` (see `src/lib/watched.ts`).
+- Video playback streams HLS from `vod.kringvarp.fo` (external server); requires network access. The playlist URL is built from each episode's `mediaId`: `https://vod.kringvarp.fo/redirect/video/_definst_/smil:smil/video/${mediaId}.smil?type=m3u8`.
+- Watch history is tracked in browser `localStorage` keyed by `show.title` → `episode.sortKey` (see `src/lib/watched.ts`).
 
 ### Routes
 
-| Route                                        | File                                                                | Description             |
-| -------------------------------------------- | ------------------------------------------------------------------- | ----------------------- |
-| `/`                                          | `src/routes/+page.svelte`                                           | Show grid (homepage)    |
-| `/sending/[showTitle]`                       | `src/routes/sending/[showTitle]/+page.svelte`                       | Episode list for a show |
-| `/sending/[showTitle]/partur/[episodeTitle]` | `src/routes/sending/[showTitle]/partur/[episodeTitle]/+page.svelte` | Video player            |
+| Route                                        | File                                                                | Description                             |
+| -------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------- |
+| `/`                                          | `src/routes/+page.svelte`                                           | Show grid (homepage)                    |
+| `/sending/[showTitle]`                       | `src/routes/sending/[showTitle]/+page.svelte`                       | Episode list for a show                 |
+| `/sending/[showTitle]/partur/[episodeTitle]` | `src/routes/sending/[showTitle]/partur/[episodeTitle]/+page.svelte` | Video player with autoplay-next-episode |
 
 ### Commands
 


### PR DESCRIPTION
Add a top-level "Purpose" section explaining that this is an alternative kid-friendly frontend for the children's TV catalogue at https://kvf.fo/vit/sjonvarp/sendingar, and walk through the three pages (front page, show page, episode player) so a new contributor sees the user flow before the technical architecture.

Also note the HLS playlist URL shape and the localStorage key layout in the Architecture section, since both are easy to miss when reading the routes in isolation.